### PR TITLE
mariaDB 10.4 -> mySQL 5.7 kompatibilitási probléma feloldása 

### DIFF
--- a/database/initialize_database.sql
+++ b/database/initialize_database.sql
@@ -51,9 +51,11 @@ CREATE TABLE IF NOT EXISTS `MESSAGES` (
 
 -- VIEWS
 CREATE VIEW IF NOT EXISTS `USERNAMES` AS
+-- CREATE VIEW `USERNAMES` AS
 SELECT username FROM USERS;
 
 CREATE VIEW IF NOT EXISTS `USER_DETAILS` AS
+-- CREATE VIEW `USER_DETAILS` AS
 SELECT USERS.id AS user_id,
        USERS.username AS username, 
        DETAILS.surname AS surname, 
@@ -61,6 +63,7 @@ SELECT USERS.id AS user_id,
 FROM USERS LEFT JOIN DETAILS ON USERS.detail_id = DETAILS.id;
 
 CREATE VIEW IF NOT EXISTS `USER_LOGINS` AS
+-- CREATE VIEW `USER_LOGINS` AS
 SELECT USERS.username AS username, 
        from_unixtime(ACCESS.last_logged_in) AS last_logged_in,
        from_unixtime(ACCESS.created_at) AS access_created_at,
@@ -72,6 +75,7 @@ FROM USERS LEFT JOIN ACCESS ON USERS.access_id = ACCESS.id
 ORDER BY logged_in_epoch DESC, access_crtd_epoch DESC, user_crtd_epoch DESC;
 
 CREATE VIEW IF NOT EXISTS `ORPHAN_ACCESS_RECORDS` AS
+-- CREATE VIEW `ORPHAN_ACCESS_RECORDS` AS
 SELECT * 
 FROM ACCESS 
 WHERE id NOT IN (
@@ -80,6 +84,7 @@ WHERE id NOT IN (
   );
 
 CREATE VIEW IF NOT EXISTS `ORPHAN_DETAILS_RECORDS` AS
+-- CREATE VIEW `ORPHAN_DETAILS_RECORDS` AS
 SELECT * 
 FROM DETAILS 
 WHERE id NOT IN (
@@ -99,4 +104,4 @@ SET @details_last_id = LAST_INSERT_ID();
 INSERT IGNORE INTO `USERS` (`id`, `username`, `created_at`, `access_id`, `detail_id`) VALUES (default, @username, UNIX_TIMESTAMP(NOW()), @access_last_id, @details_last_id);
 
 -- ADD TEST MESSAGE: ?message=test
-INSERT IGNORE INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, "test", default, UNIX_TIMESTAMP(NOW() - INTERVAL 5 MINUTE), "'guest.user@test.com'", TO_BASE64("Test Subject"), TO_BASE64("Hello,\nI hope this email finds you well!\n\n 0===}::::::::::::::> \n\nBye"));
+INSERT IGNORE INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, "test", default, UNIX_TIMESTAMP(NOW() - INTERVAL 5 MINUTE), "'guest.user@test.com'", TO_BASE64("Test Subject"), TO_BASE64("Hello,\nI hope this email finds you well!\n\n 0===}::::::::::::::> \n\nBye"));

--- a/database/initialize_database.sql
+++ b/database/initialize_database.sql
@@ -39,7 +39,7 @@ CREATE TABLE IF NOT EXISTS `USERS` (
 
 CREATE TABLE IF NOT EXISTS `MESSAGES` (
   `id` int(5) unsigned NOT NULL auto_increment,
-  --`msg_id` VARCHAR(16) default CONCAT("msg", SUBSTRING(UUID(), 1, 8), SUBSTRING(UUID(), 2, 6)) unique,
+  -- `msg_id` VARCHAR(16) default CONCAT("msg", SUBSTRING(UUID(), 1, 8), SUBSTRING(UUID(), 2, 6)) unique,
   `msg_id` VARCHAR(16) NOT NULL unique,
   `sender_id` int(5) default NULL,
   `sent_at` int(10) NOT NULL,

--- a/database/initialize_database.sql
+++ b/database/initialize_database.sql
@@ -1,16 +1,16 @@
--- DEBUG USER FOR CONNECTION
+---------- DEBUG USER FOR CONNECTION ----------
 CREATE USER IF NOT EXISTS 'debug_user'@'localhost' IDENTIFIED BY 'password';
 GRANT SELECT, INSERT, UPDATE ON *.* TO 'debug_user'@'localhost' 
 REQUIRE NONE WITH MAX_QUERIES_PER_HOUR 3600 MAX_CONNECTIONS_PER_HOUR 3600 MAX_UPDATES_PER_HOUR 3600 MAX_USER_CONNECTIONS 3600;
 GRANT SELECT, INSERT, UPDATE ON `knives\_database`.* TO 'debug_user'@'localhost';
 
--- DATABASE
+---------- DATABASE ----------
 CREATE DATABASE IF NOT EXISTS `knives_database`
 CHARACTER SET utf8 COLLATE utf8_hungarian_ci;
 
 USE `knives_database`;
 
--- TABLES
+---------- CREATE TABLES ----------
 CREATE TABLE IF NOT EXISTS `ACCESS` (
   `id` int(5) unsigned NOT NULL auto_increment,
   `created_at` int(10) NOT NULL,
@@ -49,7 +49,7 @@ CREATE TABLE IF NOT EXISTS `MESSAGES` (
   PRIMARY KEY (`id`)
 ) ENGINE = InnoDB;
 
--- VIEWS
+---------- CREATE VIEWS ----------
 CREATE VIEW IF NOT EXISTS `USERNAMES` AS
 -- CREATE VIEW `USERNAMES` AS
 SELECT username FROM USERS;
@@ -92,7 +92,7 @@ WHERE id NOT IN (
   FROM USERS
   );
 
--- REGISTER ADMIN USER
+---------- REGISTER ADMIN USER ----------
 SET @username = 'admin';
 SET @password = 'admin';
 SET @surname = 'The';
@@ -103,5 +103,5 @@ INSERT IGNORE INTO `DETAILS` (`id`, `surname`, `forename`) VALUES (default, @sur
 SET @details_last_id = LAST_INSERT_ID();
 INSERT IGNORE INTO `USERS` (`id`, `username`, `created_at`, `access_id`, `detail_id`) VALUES (default, @username, UNIX_TIMESTAMP(NOW()), @access_last_id, @details_last_id);
 
--- ADD TEST MESSAGE: ?message=test
+---------- ADD TEST MESSAGE: ?message=test ----------
 INSERT IGNORE INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, "test", default, UNIX_TIMESTAMP(NOW() - INTERVAL 5 MINUTE), "'guest.user@test.com'", TO_BASE64("Test Subject"), TO_BASE64("Hello,\nI hope this email finds you well!\n\n 0===}::::::::::::::> \n\nBye"));

--- a/database/initialize_database.sql
+++ b/database/initialize_database.sql
@@ -39,7 +39,8 @@ CREATE TABLE IF NOT EXISTS `USERS` (
 
 CREATE TABLE IF NOT EXISTS `MESSAGES` (
   `id` int(5) unsigned NOT NULL auto_increment,
-  `msg_id` VARCHAR(16) default CONCAT("msg", SUBSTRING(UUID(), 1, 8), SUBSTRING(UUID(), 2, 6)) unique,
+  --`msg_id` VARCHAR(16) default CONCAT("msg", SUBSTRING(UUID(), 1, 8), SUBSTRING(UUID(), 2, 6)) unique,
+  `msg_id` VARCHAR(16) NOT NULL unique,
   `sender_id` int(5) default NULL,
   `sent_at` int(10) NOT NULL,
   `email_address` varchar(255) NOT NULL,

--- a/database/nuke_database.sql
+++ b/database/nuke_database.sql
@@ -1,8 +1,10 @@
 -- removes all registered data and resets index counters
-TRUNCATE `knives_database`.`users`;
-TRUNCATE `knives_database`.`access`;
-TRUNCATE `knives_database`.`details`;
-TRUNCATE `knives_database`.`messages`;
+
+USE `knives_database`;
+TRUNCATE `users`;
+TRUNCATE `access`;
+TRUNCATE `details`;
+TRUNCATE `messages`;
 
 DROP DATABASE IF EXISTS `knives_database`;
 DROP USER IF EXISTS 'debug_user'@'localhost';

--- a/database/nuke_database.sql
+++ b/database/nuke_database.sql
@@ -1,10 +1,10 @@
 -- removes all registered data and resets index counters
 
 USE `knives_database`;
-TRUNCATE `users`;
-TRUNCATE `access`;
-TRUNCATE `details`;
-TRUNCATE `messages`;
+TRUNCATE `USERS`;
+TRUNCATE `ACCESS`;
+TRUNCATE `DETAILS`;
+TRUNCATE `MESSAGES`;
 
 DROP DATABASE IF EXISTS `knives_database`;
 DROP USER IF EXISTS 'debug_user'@'localhost';

--- a/database/nuke_database.sql
+++ b/database/nuke_database.sql
@@ -1,4 +1,4 @@
--- removes all registered data and resets index counters
+---------- removes all registered data and resets index counters ----------
 
 USE `knives_database`;
 TRUNCATE `USERS`;

--- a/database/populate_with_dummy_data.sql
+++ b/database/populate_with_dummy_data.sql
@@ -4,105 +4,105 @@ SET @username = 'dummyUser';
 SET @password = 'Password12345';
 SET @surname = 'Dummilton';
 SET @forename = 'Userling';
-INSERT INTO `access` (`id`, `created_at`, `last_logged_in`, `password_hash`) VALUES (default, UNIX_TIMESTAMP(NOW()), default, SHA2(CONCAT('pw_salt', @password, 'pw_pepper'), 256));
+INSERT INTO `ACCESS` (`id`, `created_at`, `last_logged_in`, `password_hash`) VALUES (default, UNIX_TIMESTAMP(NOW()), default, SHA2(CONCAT('pw_salt', @password, 'pw_pepper'), 256));
 SET @access_last_id = LAST_INSERT_ID();
-INSERT INTO `details` (`id`, `surname`, `forename`) VALUES (default, @surname, @forename);
+INSERT INTO `DETAILS` (`id`, `surname`, `forename`) VALUES (default, @surname, @forename);
 SET @details_last_id = LAST_INSERT_ID();
-INSERT INTO `users` (`id`, `username`, `created_at`, `access_id`, `detail_id`) VALUES (default, @username, UNIX_TIMESTAMP(NOW()), @access_last_id, @details_last_id);
+INSERT INTO `USERS` (`id`, `username`, `created_at`, `access_id`, `detail_id`) VALUES (default, @username, UNIX_TIMESTAMP(NOW()), @access_last_id, @details_last_id);
 SET @test_user_dummy_id = LAST_INSERT_ID();
 
 -- orphan useraccess 
 SET @password = 'randomstring';
-INSERT INTO `access` (`id`, `created_at`, `last_logged_in`, `password_hash`) VALUES (default, UNIX_TIMESTAMP(NOW() - INTERVAL 1 YEAR), default, SHA2(CONCAT('pw_salt', @password, 'pw_pepper'), 256));
+INSERT INTO `ACCESS` (`id`, `created_at`, `last_logged_in`, `password_hash`) VALUES (default, UNIX_TIMESTAMP(NOW() - INTERVAL 1 YEAR), default, SHA2(CONCAT('pw_salt', @password, 'pw_pepper'), 256));
 
 SET @username = 'testUser1';
 SET @password = 'ILoveHorses';
 SET @surname = 'Horse-Lover';
 SET @forename = 'User';
-INSERT INTO `access` (`id`, `created_at`, `last_logged_in`, `password_hash`) VALUES (default, UNIX_TIMESTAMP(NOW()), default, SHA2(CONCAT('pw_salt', @password, 'pw_pepper'), 256));
+INSERT INTO `ACCESS` (`id`, `created_at`, `last_logged_in`, `password_hash`) VALUES (default, UNIX_TIMESTAMP(NOW()), default, SHA2(CONCAT('pw_salt', @password, 'pw_pepper'), 256));
 SET @access_last_id = LAST_INSERT_ID();
-INSERT INTO `details` (`id`, `surname`, `forename`) VALUES (default, @surname, @forename);
+INSERT INTO `DETAILS` (`id`, `surname`, `forename`) VALUES (default, @surname, @forename);
 SET @details_last_id = LAST_INSERT_ID();
-INSERT INTO `users` (`id`, `username`, `created_at`, `access_id`, `detail_id`) VALUES (default, @username, UNIX_TIMESTAMP(NOW()), @access_last_id, @details_last_id);
+INSERT INTO `USERS` (`id`, `username`, `created_at`, `access_id`, `detail_id`) VALUES (default, @username, UNIX_TIMESTAMP(NOW()), @access_last_id, @details_last_id);
 SET @test_user_horse_id = LAST_INSERT_ID();
 
 -- orphan userdetail
 SET @surname = 'Doe';
 SET @forename = 'John';
-INSERT INTO `details` (`id`, `surname`, `forename`) VALUES (default, @surname, @forename);
+INSERT INTO `DETAILS` (`id`, `surname`, `forename`) VALUES (default, @surname, @forename);
 
 -- orphan userdetail
 SET @surname = 'Doe';
 SET @forename = 'Jane';
-INSERT INTO `details` (`id`, `surname`, `forename`) VALUES (default, @surname, @forename);
+INSERT INTO `DETAILS` (`id`, `surname`, `forename`) VALUES (default, @surname, @forename);
 
 SET @username = 'testUser2';
 SET @password = 'ILoveDogs';
 SET @surname = 'Dog-Lover';
 SET @forename = 'User';
-INSERT INTO `access` (`id`, `created_at`, `last_logged_in`, `password_hash`) VALUES (default, UNIX_TIMESTAMP(NOW()), default, SHA2(CONCAT('pw_salt', @password, 'pw_pepper'), 256));
+INSERT INTO `ACCESS` (`id`, `created_at`, `last_logged_in`, `password_hash`) VALUES (default, UNIX_TIMESTAMP(NOW()), default, SHA2(CONCAT('pw_salt', @password, 'pw_pepper'), 256));
 SET @access_last_id = LAST_INSERT_ID();
-INSERT INTO `details` (`id`, `surname`, `forename`) VALUES (default, @surname, @forename);
+INSERT INTO `DETAILS` (`id`, `surname`, `forename`) VALUES (default, @surname, @forename);
 SET @details_last_id = LAST_INSERT_ID();
-INSERT INTO `users` (`id`, `username`, `created_at`, `access_id`, `detail_id`) VALUES (default, @username, UNIX_TIMESTAMP(NOW()), @access_last_id, @details_last_id);
+INSERT INTO `USERS` (`id`, `username`, `created_at`, `access_id`, `detail_id`) VALUES (default, @username, UNIX_TIMESTAMP(NOW()), @access_last_id, @details_last_id);
 SET @test_user_dog_id = LAST_INSERT_ID();
 
 SET @username = 'testUser3';
 SET @password = 'ILoveCats';
 SET @surname = 'Cat-Lover';
 SET @forename = 'User';
-INSERT INTO `access` (`id`, `created_at`, `last_logged_in`, `password_hash`) VALUES (default, UNIX_TIMESTAMP(NOW()), default, SHA2(CONCAT('pw_salt', @password, 'pw_pepper'), 256));
+INSERT INTO `ACCESS` (`id`, `created_at`, `last_logged_in`, `password_hash`) VALUES (default, UNIX_TIMESTAMP(NOW()), default, SHA2(CONCAT('pw_salt', @password, 'pw_pepper'), 256));
 SET @access_last_id = LAST_INSERT_ID();
-INSERT INTO `details` (`id`, `surname`, `forename`) VALUES (default, @surname, @forename);
+INSERT INTO `DETAILS` (`id`, `surname`, `forename`) VALUES (default, @surname, @forename);
 SET @details_last_id = LAST_INSERT_ID();
-INSERT INTO `users` (`id`, `username`, `created_at`, `access_id`, `detail_id`) VALUES (default, @username, UNIX_TIMESTAMP(NOW()), @access_last_id, @details_last_id);
+INSERT INTO `USERS` (`id`, `username`, `created_at`, `access_id`, `detail_id`) VALUES (default, @username, UNIX_TIMESTAMP(NOW()), @access_last_id, @details_last_id);
 SET @test_user_cat_id = LAST_INSERT_ID();
 
 -- orphan useraccess 
 SET @password = 'password12345';
-INSERT INTO `access` (`id`, `created_at`, `last_logged_in`, `password_hash`) VALUES (default, UNIX_TIMESTAMP(NOW() - INTERVAL 1 HOUR), default, SHA2(CONCAT('pw_salt', @password, 'pw_pepper'), 256));
+INSERT INTO `ACCESS` (`id`, `created_at`, `last_logged_in`, `password_hash`) VALUES (default, UNIX_TIMESTAMP(NOW() - INTERVAL 1 HOUR), default, SHA2(CONCAT('pw_salt', @password, 'pw_pepper'), 256));
 
 
 SET @username = 'testUser4';
 SET @password = 'ILoveSharks';
 SET @surname = 'Fish-Lover';
 SET @forename = 'User';
-INSERT INTO `access` (`id`, `created_at`, `last_logged_in`, `password_hash`) VALUES (default, UNIX_TIMESTAMP(NOW()), default, SHA2(CONCAT('pw_salt', @password, 'pw_pepper'), 256));
+INSERT INTO `ACCESS` (`id`, `created_at`, `last_logged_in`, `password_hash`) VALUES (default, UNIX_TIMESTAMP(NOW()), default, SHA2(CONCAT('pw_salt', @password, 'pw_pepper'), 256));
 SET @access_last_id = LAST_INSERT_ID();
-INSERT INTO `details` (`id`, `surname`, `forename`) VALUES (default, @surname, @forename);
+INSERT INTO `DETAILS` (`id`, `surname`, `forename`) VALUES (default, @surname, @forename);
 SET @details_last_id = LAST_INSERT_ID();
-INSERT INTO `users` (`id`, `username`, `created_at`, `access_id`, `detail_id`) VALUES (default, @username, UNIX_TIMESTAMP(NOW()), @access_last_id, @details_last_id);
+INSERT INTO `USERS` (`id`, `username`, `created_at`, `access_id`, `detail_id`) VALUES (default, @username, UNIX_TIMESTAMP(NOW()), @access_last_id, @details_last_id);
 SET @test_user_fish_id = LAST_INSERT_ID();
 
 -- only works if msg_id is generated on the DB side
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 5 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Hello, is your frigde running?\n\n\nBye"));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 10 MINUTE), "'guest.user@example.hu'", TO_BASE64("Test Subject"), TO_BASE64("Hello,\n\nhow are you?\n\nI'am a guest.\n\n\nBye"));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, @test_user_dummy_id, UNIX_TIMESTAMP(NOW() - INTERVAL 15 MINUTE), "'dummy.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Hello,\n\nhow are you?\n\nI'am the dummy user.\n\n\nBye"));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, @test_user_horse_id, UNIX_TIMESTAMP(NOW() - INTERVAL 20 MINUTE), "'horse.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Hello,\n\nhow are you?\nI'am the horse user.\n\n\nBye"));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, @test_user_dog_id, UNIX_TIMESTAMP(NOW() - INTERVAL 25 MINUTE), "'dog.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Hello,\n\nhow are you?\nI'am the dog user.\n\n\nBye"));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, @test_user_cat_id, UNIX_TIMESTAMP(NOW() - INTERVAL 30 MINUTE), "'cat.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Hello,\n\nhow are you?\nI'am the cat user.\n\n\nBye"));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 33 MINUTE), "'guest.user@example.uk'", TO_BASE64("Test Subject"), TO_BASE64("ʕノ•ᴥ•ʔノ ︵ ┻━┻\n\n┻━┻ ︵ヽ(`Д´)ﾉ︵ ┻━┻\n\n¯\_( ͡° ͜ʖ ͡°)_/¯"));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, @test_user_fish_id, UNIX_TIMESTAMP(NOW() - INTERVAL 35 MINUTE), "'fish.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Hello,\n\nhow are you?\nI'am the fish user.\n\n\nBye"));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 40 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Just letting you know we featured your website on our blog roundup!\n\nBest,\nThe Popular Blog Team"));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 45 MINUTE), "'guest.user@mail.com'", TO_BASE64("Test Subject"), TO_BASE64("Do you offer a demo or trial version of your product?"));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 45 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Test - zW9X0oLMeTkP3rQ"));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 50 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("I tried using your contact form, but it didn’t go through — reaching out here instead."));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, @test_user_cat_id, UNIX_TIMESTAMP(NOW() - INTERVAL 55 MINUTE), "'cat.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("I’m looking for more technical details about knives.\nDo you have a spec sheet?"));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 60 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Hello, I recently placed an order on your website and unfortunately received the wrong item. I tried reaching out via the contact form, but haven’t received a response. I'd appreciate it if someone could assist me with a replacement or refund as soon as possible. Thanks in advance for your help."));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, @test_user_horse_id, UNIX_TIMESTAMP(NOW() - INTERVAL 65 MINUTE), "'horse.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Hello there!\n\nJust wanted to say your website looks great! One small thing — I noticed a broken link on the homepage."));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 70 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Hello! I’m interested in your services and wanted to ask about your pricing options."));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 72 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Test - dVrY7kpXLO23mne"));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 75 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Hi,\nI came across your site and had a quick question about one of your knives.\n\nCould you help?"));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, @test_user_dog_id, UNIX_TIMESTAMP(NOW() - INTERVAL 80 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Is super knife currently in stock? I'm interested in placing an order."));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 85 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Do you have a press/media kit available for download?"));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 90 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Do you offer discounts for bulk purchases?\nTIA"));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 92 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Check this cool ASCII art I made for you:\n\n⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡀\n⠀⠀⠀⠀⠀⠀⣀⢀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢠⢾⡇\n⠀⠀⣀⠤⡒⠉⠒⡄⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡰⠃⢸⠃\n⢰⣾⡐⠉⡠⠂⠜⠠⠸⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⠞⠠⡃⡿⠀\n⠈⢟⣼⡐⠠⢲⡀⠀⠀⢱⡀⠀⠀⠀⠀⠀⠀⠀⡰⢋⢰⠇⣸⠇⠀\n⠀⠈⢿⣷⡀⠁⠠⠀⠩⠀⡳⡀⠀⠀⠀⠀⢠⠞⣺⡗⠣⣐⡏⠀⠀\n⠀⠀⠈⢻⣱⡀⠁⠀⠀⢰⣆⠳⡄⠀⢀⣴⢇⣼⠛⠀⣰⡟⠀⠀⠀\n⠀⠀⠀⠀⠹⣷⡄⠘⢀⡀⠀⣇⠼⣦⠊⠞⠀⠛⡀⣰⡟⠀⠀⠀⠀\n⠀⠀⠀⠀⠀⠘⢿⣄⣁⡡⠒⢷⣝⠏⠳⣦⣀⡀⣼⠏⠀⠀⠀⠀⠀\n⠀⠀⠀⠀⠀⠀⠀⠙⠁⠀⡠⣛⣻⣆⢶⠘⢟⠾⠋⠀⠀⠀⠀⠀⠀\n⠀⠀⠀⠀⠀⠀⠀⠀⠀⡔⡧⣩⠟⠙⣷⡤⡬⣣⠀⠀⠀⠀⠀⠀⠀\n⠀⠀⠀⠀⠀⠀⠀⠀⠘⣬⣵⠃⠀⠀⠘⣧⣤⠞⠀⠀⠀⠀⠀⠀⠀"));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, @test_user_dummy_id, UNIX_TIMESTAMP(NOW() - INTERVAL 95 MINUTE), "'dummy.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Test - X7b92LmTqP1oKej"));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 103 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Test - aVz39PxkLe8TRyo"));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 106 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Test - N0rBq15ZsXvdM6J"));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 109 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Test - mUoT9EjwF7KzLqx"));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, @test_user_fish_id, UNIX_TIMESTAMP(NOW() - INTERVAL 110 MINUTE), "'fish.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Test - Wq8eJ7zLMy0kRpN"));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, @test_user_dummy_id, UNIX_TIMESTAMP(NOW() - INTERVAL 115 MINUTE), "'dummy.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Test - b3XzQWm94Et7uVo"));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 120 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Test - TfK1pZxqvYO29le"));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 122 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Test - EqLzM49KnT8rWvo"));
-INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 150 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Test - 1152sdascvas562"));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 5 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Hello, is your frigde running?\n\n\nBye"));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 10 MINUTE), "'guest.user@example.hu'", TO_BASE64("Test Subject"), TO_BASE64("Hello,\n\nhow are you?\n\nI'am a guest.\n\n\nBye"));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, @test_user_dummy_id, UNIX_TIMESTAMP(NOW() - INTERVAL 15 MINUTE), "'dummy.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Hello,\n\nhow are you?\n\nI'am the dummy user.\n\n\nBye"));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, @test_user_horse_id, UNIX_TIMESTAMP(NOW() - INTERVAL 20 MINUTE), "'horse.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Hello,\n\nhow are you?\nI'am the horse user.\n\n\nBye"));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, @test_user_dog_id, UNIX_TIMESTAMP(NOW() - INTERVAL 25 MINUTE), "'dog.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Hello,\n\nhow are you?\nI'am the dog user.\n\n\nBye"));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, @test_user_cat_id, UNIX_TIMESTAMP(NOW() - INTERVAL 30 MINUTE), "'cat.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Hello,\n\nhow are you?\nI'am the cat user.\n\n\nBye"));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 33 MINUTE), "'guest.user@example.uk'", TO_BASE64("Test Subject"), TO_BASE64("ʕノ•ᴥ•ʔノ ︵ ┻━┻\n\n┻━┻ ︵ヽ(`Д´)ﾉ︵ ┻━┻\n\n¯\_( ͡° ͜ʖ ͡°)_/¯"));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, @test_user_fish_id, UNIX_TIMESTAMP(NOW() - INTERVAL 35 MINUTE), "'fish.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Hello,\n\nhow are you?\nI'am the fish user.\n\n\nBye"));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 40 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Just letting you know we featured your website on our blog roundup!\n\nBest,\nThe Popular Blog Team"));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 45 MINUTE), "'guest.user@mail.com'", TO_BASE64("Test Subject"), TO_BASE64("Do you offer a demo or trial version of your product?"));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 45 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Test - zW9X0oLMeTkP3rQ"));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 50 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("I tried using your contact form, but it didn’t go through — reaching out here instead."));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, @test_user_cat_id, UNIX_TIMESTAMP(NOW() - INTERVAL 55 MINUTE), "'cat.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("I’m looking for more technical details about knives.\nDo you have a spec sheet?"));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 60 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Hello, I recently placed an order on your website and unfortunately received the wrong item. I tried reaching out via the contact form, but haven’t received a response. I'd appreciate it if someone could assist me with a replacement or refund as soon as possible. Thanks in advance for your help."));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, @test_user_horse_id, UNIX_TIMESTAMP(NOW() - INTERVAL 65 MINUTE), "'horse.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Hello there!\n\nJust wanted to say your website looks great! One small thing — I noticed a broken link on the homepage."));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 70 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Hello! I’m interested in your services and wanted to ask about your pricing options."));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 72 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Test - dVrY7kpXLO23mne"));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 75 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Hi,\nI came across your site and had a quick question about one of your knives.\n\nCould you help?"));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, @test_user_dog_id, UNIX_TIMESTAMP(NOW() - INTERVAL 80 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Is super knife currently in stock? I'm interested in placing an order."));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 85 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Do you have a press/media kit available for download?"));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 90 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Do you offer discounts for bulk purchases?\nTIA"));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 92 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Check this cool ASCII art I made for you:\n\n⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡀\n⠀⠀⠀⠀⠀⠀⣀⢀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢠⢾⡇\n⠀⠀⣀⠤⡒⠉⠒⡄⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡰⠃⢸⠃\n⢰⣾⡐⠉⡠⠂⠜⠠⠸⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⠞⠠⡃⡿⠀\n⠈⢟⣼⡐⠠⢲⡀⠀⠀⢱⡀⠀⠀⠀⠀⠀⠀⠀⡰⢋⢰⠇⣸⠇⠀\n⠀⠈⢿⣷⡀⠁⠠⠀⠩⠀⡳⡀⠀⠀⠀⠀⢠⠞⣺⡗⠣⣐⡏⠀⠀\n⠀⠀⠈⢻⣱⡀⠁⠀⠀⢰⣆⠳⡄⠀⢀⣴⢇⣼⠛⠀⣰⡟⠀⠀⠀\n⠀⠀⠀⠀⠹⣷⡄⠘⢀⡀⠀⣇⠼⣦⠊⠞⠀⠛⡀⣰⡟⠀⠀⠀⠀\n⠀⠀⠀⠀⠀⠘⢿⣄⣁⡡⠒⢷⣝⠏⠳⣦⣀⡀⣼⠏⠀⠀⠀⠀⠀\n⠀⠀⠀⠀⠀⠀⠀⠙⠁⠀⡠⣛⣻⣆⢶⠘⢟⠾⠋⠀⠀⠀⠀⠀⠀\n⠀⠀⠀⠀⠀⠀⠀⠀⠀⡔⡧⣩⠟⠙⣷⡤⡬⣣⠀⠀⠀⠀⠀⠀⠀\n⠀⠀⠀⠀⠀⠀⠀⠀⠘⣬⣵⠃⠀⠀⠘⣧⣤⠞⠀⠀⠀⠀⠀⠀⠀"));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, @test_user_dummy_id, UNIX_TIMESTAMP(NOW() - INTERVAL 95 MINUTE), "'dummy.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Test - X7b92LmTqP1oKej"));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 103 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Test - aVz39PxkLe8TRyo"));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 106 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Test - N0rBq15ZsXvdM6J"));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 109 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Test - mUoT9EjwF7KzLqx"));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, @test_user_fish_id, UNIX_TIMESTAMP(NOW() - INTERVAL 110 MINUTE), "'fish.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Test - Wq8eJ7zLMy0kRpN"));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, @test_user_dummy_id, UNIX_TIMESTAMP(NOW() - INTERVAL 115 MINUTE), "'dummy.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Test - b3XzQWm94Et7uVo"));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 120 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Test - TfK1pZxqvYO29le"));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 122 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Test - EqLzM49KnT8rWvo"));
+INSERT INTO `MESSAGES` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 150 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Test - 1152sdascvas562"));

--- a/database/populate_with_dummy_data.sql
+++ b/database/populate_with_dummy_data.sql
@@ -74,6 +74,7 @@ SET @details_last_id = LAST_INSERT_ID();
 INSERT INTO `users` (`id`, `username`, `created_at`, `access_id`, `detail_id`) VALUES (default, @username, UNIX_TIMESTAMP(NOW()), @access_last_id, @details_last_id);
 SET @test_user_fish_id = LAST_INSERT_ID();
 
+-- only works if msg_id is generated on the DB side
 INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 5 MINUTE), "'guest.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Hello, is your frigde running?\n\n\nBye"));
 INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, default, UNIX_TIMESTAMP(NOW() - INTERVAL 10 MINUTE), "'guest.user@example.hu'", TO_BASE64("Test Subject"), TO_BASE64("Hello,\n\nhow are you?\n\nI'am a guest.\n\n\nBye"));
 INSERT INTO `messages` (`id`, `msg_id`, `sender_id`, `sent_at`, `email_address`, `subject`, `msg_text`) VALUES (default, default, @test_user_dummy_id, UNIX_TIMESTAMP(NOW() - INTERVAL 15 MINUTE), "'dummy.user@example.com'", TO_BASE64("Test Subject"), TO_BASE64("Hello,\n\nhow are you?\n\nI'am the dummy user.\n\n\nBye"));

--- a/database/queries.sql
+++ b/database/queries.sql
@@ -1,12 +1,12 @@
 USE `knives_database`;
 
--- check if username already exists
+---------- check if username already exists ----------
 SET @username = "admin";
 SELECT count(username) AS username_exists
 FROM USERNAMES 
 WHERE username = @username;
 
--- get password hash by username (username is unique)
+---------- get password hash by username (username is unique) ----------
 SET @username = "admin";
 SELECT password_hash 
 FROM ACCESS 
@@ -16,19 +16,19 @@ WHERE id IN (
     WHERE username = @username
     );
 
--- get user details (username is unique)
+---------- get user details (username is unique) ----------
 SET @username = "admin";
 SELECT surname, forename
 FROM USER_DETAILS
 WHERE username = @username;
 
--- get message by msg_id
+---------- get message by msg_id ----------
 SET @message_id = "msg...";
 SELECT * 
 FROM MESSAGES
 WHERE msg_id = @message_id;
 
--- get all messages paginated
+---------- get all messages paginated ----------
 SET @start = 0;
 SET @page_size = 5;
 SELECT * 

--- a/database/updates.sql
+++ b/database/updates.sql
@@ -1,6 +1,6 @@
 USE `knives_database`;
 
--- update login timestamp
+---------- update login timestamp ----------
 SET @username = "admin";
 UPDATE ACCESS
 SET last_logged_in = UNIX_TIMESTAMP(NOW())

--- a/includes/messaging_utils.inc.php
+++ b/includes/messaging_utils.inc.php
@@ -169,7 +169,7 @@ function get_user_id_by_username($username) {
 
 function save_new_message($sender_id, $email_address, $message_subject, $message_body): string {
     $insert_new_message_template = "INSERT INTO MESSAGES VALUES (default, :message_id, :sender_id, UNIX_TIMESTAMP(NOW()), :email_address, :message_subject, :message_body);";
-    $new_message_id = generate_new_message_id()
+    $new_message_id = generate_new_message_id();
     $insert_new_message_params = array(
         ':message_id' => $new_message_id,
         ':sender_id' => $sender_id,

--- a/includes/messaging_utils.inc.php
+++ b/includes/messaging_utils.inc.php
@@ -93,6 +93,10 @@ function parse_pagination_size($DATA, $key = 'size'): ?int {
     return $value;
 }
 
+function generate_new_message_id(): string {
+    return uniqid(prefix: 'msg');
+}
+
 function encrypt_message_content($text) {
     return base64_encode($text); // base64 is a weak encoding, not a encryption (it was choosed only to demo the functionality)
 }
@@ -164,8 +168,9 @@ function get_user_id_by_username($username) {
 }
 
 function save_new_message($sender_id, $email_address, $message_subject, $message_body): string {        
-    $insert_new_message_template = "INSERT INTO MESSAGES VALUES (default, default, :sender_id, UNIX_TIMESTAMP(NOW()), :email_address, :message_subject, :message_body);";
+    $insert_new_message_template = "INSERT INTO MESSAGES VALUES (default, :message_id, :sender_id, UNIX_TIMESTAMP(NOW()), :email_address, :message_subject, :message_body);";
     $insert_new_message_params = array(
+        ':message_id' => generate_new_message_id(),
         ':sender_id' => $sender_id,
         ':email_address' => $email_address, // email address should handled as sensitive data too (left uncrypted for presentation propuses)
         ':message_subject' => encrypt_message_content($message_subject),

--- a/includes/messaging_utils.inc.php
+++ b/includes/messaging_utils.inc.php
@@ -178,16 +178,8 @@ function save_new_message($sender_id, $email_address, $message_subject, $message
         ':message_body' => encrypt_message_content($message_body),
     );
 
-    $data_access_layer = DataAccessLayerSingleton::getInstance();
-    try {
-        $data_access_layer->beginTransaction();
-        $data_access_layer->executeCommand($insert_new_message_template, $insert_new_message_params);
-        $data_access_layer->commit();
-        return $new_message_id;
-    } catch (Exception $e) {
-        $data_access_layer->rollBack();
-        throw $e;
-    }
+    DataAccessLayerSingleton::getInstance()->executeCommand($insert_new_message_template, $insert_new_message_params);
+    return $new_message_id;
 }
 
 function message_exists($message_id): bool {


### PR DESCRIPTION
# Description
<!-- Please summarize what has been changed/added/removed -->

As turns out the provider we want to use to host the website is using an older version of mySQL
CONCAT(); SUBSTR(); UUID() and other function usage is not available at mySQL 5.7.42 (only from version 8.0)

This missing capability only affected the message_id generation, so every new msg_id will be generated at the application side 

# Screenshots
<!-- Include screenshots/gifs/screenrecordings if make scence -->

(no visible change)

# Checks
<!-- Please check this only if it's true -->
- [x] I tested and verified the changes made.
